### PR TITLE
Upgrade the versions in dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,32 +1,25 @@
-# Fetch ubuntu 18.04 LTS docker image
-FROM ubuntu:18.04
+# Fetch ubuntu 22.04 LTS docker image
+FROM ubuntu:22.04
 
-ENV DEBIAN_FRONTEND=noninteractive 
-#[DEPRECATED] Make a copy of ubuntu apt repository before modifying it. 
-#RUN mv /etc/apt/sources.list /sources.list
-#[DEPRECATED] Now change the default ubuntu apt repositry, which is VERY slow, to another mirror that is much faster. It assumes the host already has created a sources.list.
-#COPY sources.list /etc/apt/sources.list
-COPY WordCount.java /etc/apt/WordCount.java
-COPY TopWords.java /etc/apt/TopWords.java
-
-#uncomment this line to find the fastest ubuntu repository at the time. Probably overkill, so disabling for now
-#Note that this functionality is untested and might need debugging a bit.
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update apt, and install Java + curl + wget on your ubuntu image.
-RUN \
-  apt-get update && \
-  apt-get install -y curl vim wget expect git zip unzip && \
-  apt-get install -y openjdk-8-jdk 
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    vim \
+    wget \
+    expect \
+    git \
+    zip \
+    unzip \
+    openjdk-17-jdk \
+    python3 \
+    && apt-get clean
 
-RUN \
-  apt-get install -y python3 
-  # && \
-  #apt-get install -y python3-pip
-
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-2.9.2/hadoop-2.9.2.tar.gz" | tar -xz -C /usr/local/
-RUN cd /usr/local && ln -s ./hadoop-2.9.2 hadoop
-
+RUN curl -s "https://archive.apache.org/dist/hadoop/core/hadoop-3.3.4/hadoop-3.3.4.tar.gz" | tar -xz -C /usr/local/ \
+    && ln -s /usr/local/hadoop-3.3.4 /usr/local/hadoop \
+    && chmod a+rwx -R /usr/local/hadoop/
 
 ENV HADOOP_PREFIX /usr/local/hadoop
 ENV HADOOP_COMMON_HOME /usr/local/hadoop
@@ -35,28 +28,43 @@ ENV HADOOP_MAPRED_HOME /usr/local/hadoop
 ENV HADOOP_YARN_HOME /usr/local/hadoop
 ENV HADOOP_CONF_DIR /usr/local/hadoop/etc/hadoop
 ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
-ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar
+# ENV HADOOP_CLASSPATH $JAVA_HOME/lib/tools.jar
 ENV PATH="/usr/local/hadoop/bin:${PATH}"
 
-RUN sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
-RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+# Test the arch and set JAVA_HOME accordingly:
+# ARM64/aarch64: /usr/lib/jvm/java-8-openjdk-arm64
+# X84_64: /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+RUN if [ "$(uname -m)" = "x86_64" ]; then export JAVA_HOME=/usr/lib/jvm/java-1.17.0-openjdk-amd64; else export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64; fi \
+    && export HADOOP_CLASSPATH=$JAVA_HOME/lib/tools.jar \
+    && sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && sed -i "/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && echo "export JAVA_HOME=$JAVA_HOME" >> $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh \
+    && echo "export JAVA_HOME=$JAVA_HOME" >> /root/.bashrc
+
+# RUN sed -i "/^export JAVA_HOME/ s:.*:export HADOOP_PREFIX=/usr/local/hadoop HADOOP_HOME=/usr/local/hadoop\n:" $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+# RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 
 
-RUN chmod a+rwx -R /usr/local/hadoop/
 #COPY autosu /usr/local/bin
 #RUN chmod 777 /usr/local/bin/autosu
 #RUN adduser hadoopuser --disabled-password --gecos ""
 #RUN echo 'hadoopuser:hadooppass' | chpasswd
 
 # Download and setup Apache Spark
-RUN curl -s "https://archive.apache.org/dist/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz" | tar -xz -C /usr/local/
-RUN ln -s /usr/local/spark-2.2.1-bin-hadoop2.7 /usr/local/spark
-
-ENV SPARK_HOME /usr/local/spark
+RUN curl -s "https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz" | tar -xz  -C /usr/local/ \
+    && ln -s /usr/local/spark-3.3.2-bin-hadoop3 /usr/local/spark \
+    && chmod a+rwx -R /usr/local/spark/
 ENV PATH="/usr/local/spark/bin:${PATH}"
-RUN chmod a+rwx -R /usr/local/spark/
+ENV SPARK_HOME /usr/local/spark
 
 # Make vim nice
 RUN echo "set background=dark" >> ~/.vimrc
-
 ENV PYSPARK_PYTHON=python3
+
+COPY WordCount.java /etc/apt/WordCount.java
+COPY TopWords.java /etc/apt/TopWords.java
+
+# [Optional] Set working path to /cs498, and run the following command to start the container with code:
+# WORKDIR /cs498
+# docker run -it --rm --mount type=bind,source=$PATH_TO_CODE,target=/cs498/ sample_image.v1 /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # MP5_SparkMapReduce_Template
 This is the template for MP5 Spark MapReduce, including the Docker image and Python template.
+
+## Log 
+Last updated in April 2023, by Shujing Yang (shujing6@illinois.edu)
+
+Udpated in May 2021, by Sam Cheng (rcheng12@illinois.edu)


### PR DESCRIPTION
This includes the up-to-date changes done by Ruijie including the following: 

Modify the Docker: 1) auto detect ARCH and set JAVA_HOME dynamically; 2) update ubuntu:22.04; 3) update spark 3.3.2; 4) Clean the dockerfile to accelerate build time and reduce image size.

And upgrade the spark to the most recent stable release of 3.4.0.